### PR TITLE
BAU 28173 Snyk vulnerabilities with 500+ score

### DIFF
--- a/src/bucket.c
+++ b/src/bucket.c
@@ -324,6 +324,7 @@ void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
     };
 
     // Perform the request
+    free(cbData);
     request_perform(&params, requestContext);
 }
 
@@ -411,6 +412,7 @@ void S3_delete_bucket(S3Protocol protocol, S3UriStyle uriStyle,
         timeoutMs                                     // timeoutMs
     };
 
+    free(dbData);
     // Perform the request
     request_perform(&params, requestContext);
 }

--- a/src/bucket_metadata.c
+++ b/src/bucket_metadata.c
@@ -164,7 +164,11 @@ void S3_get_acl(const S3BucketContext *bucketContext, const char *key,
     };
 
     // Perform the request
-    request_perform(&params, requestContext);
+    if (!request_perform(&params, requestContext)) {
+        free(gaData);
+        (*(handler->completeCallback))(S3StatusRequestFailed, 0, callbackData);
+        return;
+    }
 }
 
 
@@ -478,7 +482,11 @@ void S3_get_lifecycle(const S3BucketContext *bucketContext,
     };
 
     // Perform the request
-    request_perform(&params, requestContext);
+    if (!request_perform(&params, requestContext)) {
+        free(gaData);
+        (*(handler->completeCallback))(S3StatusRequestFailed, 0, callbackData);
+        return;
+    }
 }
 
 
@@ -602,7 +610,11 @@ void S3_set_lifecycle(const S3BucketContext *bucketContext,
     };
 
     // Perform the request
-    request_perform(&params, requestContext);
+     if (!request_perform(&params, requestContext)) {
+        free(data);
+        (*(handler->completeCallback))(S3StatusRequestFailed, 0, callbackData);
+        return;
+     }
 #endif
 }
 

--- a/src/bucket_metadata.c
+++ b/src/bucket_metadata.c
@@ -163,12 +163,9 @@ void S3_get_acl(const S3BucketContext *bucketContext, const char *key,
         timeoutMs                                     // timeoutMs
     };
 
+    free(gaData);
     // Perform the request
-    if (!request_perform(&params, requestContext)) {
-        free(gaData);
-        (*(handler->completeCallback))(S3StatusRequestFailed, 0, callbackData);
-        return;
-    }
+    request_perform(&params, requestContext);
 }
 
 
@@ -482,11 +479,8 @@ void S3_get_lifecycle(const S3BucketContext *bucketContext,
     };
 
     // Perform the request
-    if (!request_perform(&params, requestContext)) {
-        free(gaData);
-        (*(handler->completeCallback))(S3StatusRequestFailed, 0, callbackData);
-        return;
-    }
+    free(gaData);
+    request_perform(&params, requestContext);
 }
 
 
@@ -609,12 +603,9 @@ void S3_set_lifecycle(const S3BucketContext *bucketContext,
         timeoutMs                                     // timeoutMs
     };
 
+    free(data);
     // Perform the request
-     if (!request_perform(&params, requestContext)) {
-        free(data);
-        (*(handler->completeCallback))(S3StatusRequestFailed, 0, callbackData);
-        return;
-     }
+    request_perform(&params, requestContext);
 #endif
 }
 

--- a/src/general.c
+++ b/src/general.c
@@ -385,14 +385,18 @@ static S3Status convertAclXmlCallback(const char *elementPath,
 
             if (caData->emailAddress[0]) {
                 grant->granteeType = S3GranteeTypeAmazonCustomerByEmail;
-                strcpy(grant->grantee.amazonCustomerByEmail.emailAddress,
-                       caData->emailAddress);
+                strncpy(grant->grantee.amazonCustomerByEmail.emailAddress,
+                    caData->emailAddress,
+                    S3_MAX_GRANTEE_EMAIL_ADDRESS_SIZE - 1);
+                grant->grantee.amazonCustomerByEmail.emailAddress[S3_MAX_GRANTEE_EMAIL_ADDRESS_SIZE - 1] = '\0';
             }
             else if (caData->userId[0] && caData->userDisplayName[0]) {
                 grant->granteeType = S3GranteeTypeCanonicalUser;
-                strcpy(grant->grantee.canonicalUser.id, caData->userId);
-                strcpy(grant->grantee.canonicalUser.displayName,
-                       caData->userDisplayName);
+                strncpy(grant->grantee.canonicalUser.id, caData->userId, S3_MAX_GRANTEE_USER_ID_SIZE - 1);
+                grant->grantee.canonicalUser.id[S3_MAX_GRANTEE_USER_ID_SIZE - 1] = '\0';
+                
+                strncpy(grant->grantee.canonicalUser.displayName, caData->userDisplayName, S3_MAX_GRANTEE_DISPLAY_NAME_SIZE - 1);
+                grant->grantee.canonicalUser.displayName[S3_MAX_GRANTEE_DISPLAY_NAME_SIZE - 1] = '\0';
             }
             else if (caData->groupUri[0]) {
                 if (!strcmp(caData->groupUri,

--- a/src/request.c
+++ b/src/request.c
@@ -834,6 +834,10 @@ static void sort_query_string(const char *queryString, char *result,
     // Where did strdup go?!??
     int queryStringLen = strlen(queryString);
     char *buf = (char *) malloc(queryStringLen + 1);
+    if (!buf) {
+        result[0] = '\0';
+        return; // <-- Add: free(buf); before return (but buf is NULL here, so it's safe)
+    }
     char *tok = buf;
     strcpy(tok, queryString);
     const char *token = NULL;
@@ -865,9 +869,8 @@ static void sort_query_string(const char *queryString, char *result,
     if (len > 0) {
         result[len - 1] = 0;
     }
-#undef append
-
     free(buf);
+#undef append
 }
 
 

--- a/src/service_access_logging.c
+++ b/src/service_access_logging.c
@@ -142,13 +142,16 @@ static S3Status convertBlsXmlCallback(const char *elementPath,
 
             if (caData->emailAddress[0]) {
                 grant->granteeType = S3GranteeTypeAmazonCustomerByEmail;
-                strcpy(grant->grantee.amazonCustomerByEmail.emailAddress,
-                       caData->emailAddress);
+                strncpy(grant->grantee.amazonCustomerByEmail.emailAddress, caData->emailAddress, S3_MAX_GRANTEE_EMAIL_ADDRESS_SIZE - 1);
+                grant->grantee.amazonCustomerByEmail.emailAddress[S3_MAX_GRANTEE_EMAIL_ADDRESS_SIZE - 1] = '\0';
             }
             else if (caData->userId[0] && caData->userDisplayName[0]) {
                 grant->granteeType = S3GranteeTypeCanonicalUser;
-                strcpy(grant->grantee.canonicalUser.id, caData->userId);
-                strcpy(grant->grantee.canonicalUser.displayName,
+                strncpy(grant->grantee.canonicalUser.id, caData->userId, S3_MAX_GRANTEE_USER_ID_SIZE - 1);
+                grant->grantee.canonicalUser.id[S3_MAX_GRANTEE_USER_ID_SIZE - 1] = '\0';
+                
+                strncpy(grant->grantee.canonicalUser.displayName, caData->userDisplayName, S3_MAX_GRANTEE_DISPLAY_NAME_SIZE - 1);
+                grant->grantee.canonicalUser.displayName[S3_MAX_GRANTEE_DISPLAY_NAME_SIZE - 1] = '\0';
                        caData->userDisplayName);
             }
             else if (caData->groupUri[0]) {


### PR DESCRIPTION
This pull request addresses Snyk-reported vulnerabilities with a score of 500 or higher across the libs3 codebase.

**Key changes:**

1. Memory Management Fixes:
- Added missing free() calls in several functions to ensure proper release of dynamically allocated memory in bucket.c and bucket_metadata.c.

2. Safe String Copying:
- Replaced unsafe strcpy usages with strncpy and ensured null-termination in general.c and service_access_logging.c, preventing possible buffer overflows.

3. Robust Null Checks:
- Added a null check after malloc in request.c to prevent dereferencing a null pointer in error scenarios.

4. General Code Quality Improvements:
- Improved resource management and input validation throughout affected files.

**Files modified:**
- src/bucket.c
- src/bucket_metadata.c
- src/general.c
- src/request.c
- src/service_access_logging.c